### PR TITLE
Add Remap to Mixin Json to Make the Mod work

### DIFF
--- a/src/main/resources/catjammies.mixins.json
+++ b/src/main/resources/catjammies.mixins.json
@@ -2,6 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "com.buuz135.catjammies.mixin",
+    "refmap": "catjammies.refmap.json",
     "compatibilityLevel": "JAVA_17",
     "client": [
         "CatModelMixin"


### PR DESCRIPTION
Forgot to add the refmap key, so the mixin config wasn't able to pick up the parameter at all. This should fix the mod so it works in production.